### PR TITLE
Undefined SerializationTypeMismatch error

### DIFF
--- a/gemfiles/activerecord42.gemfile.lock
+++ b/gemfiles/activerecord42.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    gigo-activerecord (2.0.1)
+    gigo-activerecord (2.0.2)
       activerecord (>= 4.2.0)
       gigo
 

--- a/gemfiles/activerecord50.gemfile.lock
+++ b/gemfiles/activerecord50.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    gigo-activerecord (2.0.1)
+    gigo-activerecord (2.0.2)
       activerecord (>= 4.2.0)
       gigo
 

--- a/gemfiles/activerecord51.gemfile.lock
+++ b/gemfiles/activerecord51.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    gigo-activerecord (2.0.1)
+    gigo-activerecord (2.0.2)
       activerecord (>= 4.2.0)
       gigo
 

--- a/gemfiles/activerecord52.gemfile.lock
+++ b/gemfiles/activerecord52.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    gigo-activerecord (2.0.1)
+    gigo-activerecord (2.0.2)
       activerecord (>= 4.2.0)
       gigo
 

--- a/lib/gigo/active_record/base.rb
+++ b/lib/gigo/active_record/base.rb
@@ -44,9 +44,6 @@ module GIGO
       class GigoCoder
         attr_reader :klass
 
-        class SerializationTypeMismatch < StandardError
-        end
-
         def initialize(klass)
           @klass = klass
           @default_internal = Encoding.default_internal
@@ -57,7 +54,7 @@ module GIGO
           Encoding.default_internal = GIGO.encoding
           value = YAML.load(GIGO.load(yaml))
           unless value.is_a?(klass)
-            raise SerializationTypeMismatch, "Attribute was supposed to be a #{klass.to_s}, but was a #{value.class}: #{value.inspect}"
+            raise ::ActiveRecord::SerializationTypeMismatch, "Attribute was supposed to be a #{klass.to_s}, but was a #{value.class}: #{value.inspect}"
           end
           value
         ensure
@@ -67,7 +64,7 @@ module GIGO
         def dump(value)
           return klass.new.to_yaml if value.nil?
           unless value.is_a?(klass)
-            raise SerializationTypeMismatch, "Attribute was supposed to be a #{klass.to_s}, but was a #{value.class}: #{value.inspect}"
+            raise ::ActiveRecord::SerializationTypeMismatch, "Attribute was supposed to be a #{klass.to_s}, but was a #{value.class}: #{value.inspect}"
           end
           value.to_yaml
         end

--- a/lib/gigo/active_record/base.rb
+++ b/lib/gigo/active_record/base.rb
@@ -57,7 +57,7 @@ module GIGO
           Encoding.default_internal = GIGO.encoding
           value = YAML.load(GIGO.load(yaml))
           unless value.is_a?(klass)
-            raise SerializationTypeMismatch, "Attribute was supposed to be a #{klass.to_s}, but was a #{value.class}."
+            raise SerializationTypeMismatch, "Attribute was supposed to be a #{klass.to_s}, but was a #{value.class}: #{value.inspect}"
           end
           value
         ensure
@@ -67,7 +67,7 @@ module GIGO
         def dump(value)
           return klass.new.to_yaml if value.nil?
           unless value.is_a?(klass)
-            raise SerializationTypeMismatch, "Attribute was supposed to be a #{klass.to_s}, but was a #{value.class}."
+            raise SerializationTypeMismatch, "Attribute was supposed to be a #{klass.to_s}, but was a #{value.class}: #{value.inspect}"
           end
           value.to_yaml
         end

--- a/lib/gigo/active_record/base.rb
+++ b/lib/gigo/active_record/base.rb
@@ -57,7 +57,7 @@ module GIGO
           Encoding.default_internal = GIGO.encoding
           value = YAML.load(GIGO.load(yaml))
           unless value.is_a?(klass)
-            raise SerializationTypeMismatch, "Attribute was supposed to be a #{klass.to_s}, but was a #{hash.class}."
+            raise SerializationTypeMismatch, "Attribute was supposed to be a #{klass.to_s}, but was a #{value.class}."
           end
           value
         ensure

--- a/lib/gigo/active_record/base.rb
+++ b/lib/gigo/active_record/base.rb
@@ -44,6 +44,9 @@ module GIGO
       class GigoCoder
         attr_reader :klass
 
+        class SerializationTypeMismatch < StandardError
+        end
+
         def initialize(klass)
           @klass = klass
           @default_internal = Encoding.default_internal
@@ -74,4 +77,3 @@ module GIGO
 end
 
 ActiveRecord::Base.extend GIGO::ActiveRecord::Base
-

--- a/lib/gigo/active_record/version.rb
+++ b/lib/gigo/active_record/version.rb
@@ -1,5 +1,5 @@
 module GIGO
   module ActiveRecord
-    VERSION = "2.0.1"
+    VERSION = "2.0.2"
   end
 end


### PR DESCRIPTION
### Description

Currently `GigoCoder::SerializationTypeMismatch` is not defined, which causes the following error in the gem user app:

```rb
NameError: uninitialized constant GIGO::ActiveRecord::Base::GigoCoder::SerializationTypeMismatch
```

The error message is right. We need to define our custom error before using it.

https://github.com/customink/gigo-activerecord/blob/87c03b451bfdcbae71ec71916c49dcdfa4b135de/lib/gigo/active_record/base.rb#L52-L70

Related PR: https://github.com/customink/gigo-activerecord/pull/3

### Changes

- ~Define  `GigoCoder::SerializationTypeMismatch`~ Use fully-qualified error name `::ActiveRecord::SerializationTypeMismatch`
- Correct the error message: `hash` is probably a typo, meant to be `value`
- Show the value in the error message

### Notes

- Alternatively we could make the error be a generic `RuntimeError`
- This bug was discovered in our Rails Backend Rails 5.0 QA.
- It would be nice to be able to see actual value in the error message for debuggability

![gigo error message improved Screen Shot 2022-02-02 at 3 25 32 PM](https://user-images.githubusercontent.com/7563926/152233244-78fa9e67-7dd3-42bd-8fde-aee3227b52b7.png)
